### PR TITLE
Fix windows path string in ghost_deploy

### DIFF
--- a/ghost_deploy.py
+++ b/ghost_deploy.py
@@ -31,7 +31,7 @@ def create_autostart_linux(target_dir):
     except Exception as e:
         print(f"[!] Failed to write rc.local: {e}")
 
-def install_payload(zip_path="aria_node.zip", target_path="C:\Users\Public\Aria"):
+def install_payload(zip_path="aria_node.zip", target_path=r"C:\\Users\\Public\\Aria"):
     os.makedirs(target_path, exist_ok=True)
     extract_payload(zip_path, target_path)
     if platform.system() == "Windows":


### PR DESCRIPTION
## Summary
- fix ghost_deploy windows path string causing syntax error

## Testing
- `python3 -m compileall -q ghost_deploy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4805e26c832ba7aabaedfcd91375