### PR TITLE
Implement swarm manifest ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ python -m grpc_tools.protoc -I./proto --python_out=./proto --grpc_python_out=./p
 - [Plugin Trigger Engine](docs/plugin_trigger_engine_usage.md)
 - [Plugin Development](docs/plugins.md)
 - [Memory Sync Architecture](docs/grpc_sync.md)
+- [Swarm Manifest Ledger](docs/manifest_ledger.md)
 - [Memory Sync Quickref](docs/memory_sync_quickref.md)
 
 ---

--- a/docs/manifest_ledger.md
+++ b/docs/manifest_ledger.md
@@ -1,0 +1,18 @@
+# Swarm Manifest Ledger
+
+This document describes how the plugin ledger maintains a directed acyclic graph (DAG) of plugin ancestry. Each plugin is identified by the SHA256 hash of its source code. Entries are stored in `memory/plugin_ledger.json`.
+
+## Entry Format
+```json
+{
+  "plugin_hash": "<sha256>",
+  "parent_hash": "<sha256 or null>",
+  "lineage_map": {},
+  "label": "optional human label",
+  "timestamp": 1710000000.0
+}
+```
+
+## Usage
+Plugins register themselves via `net.plugin_ledger.register_plugin(code, parent_hash)`.
+The resulting ledger represents evolutionary history without requiring global consensus.

--- a/net/plugin_ledger.py
+++ b/net/plugin_ledger.py
@@ -1,0 +1,55 @@
+"""Plugin lineage ledger using SHA256 hashes."""
+
+import os
+import json
+import time
+import hashlib
+
+LEDGER_PATH = "memory/plugin_ledger.json"
+
+
+def _compute_hash(code: str) -> str:
+    return hashlib.sha256(code.encode("utf-8")).hexdigest()
+
+
+def load_ledger() -> dict:
+    try:
+        with open(LEDGER_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_ledger(ledger: dict) -> None:
+    os.makedirs(os.path.dirname(LEDGER_PATH), exist_ok=True)
+    with open(LEDGER_PATH, "w", encoding="utf-8") as f:
+        json.dump(ledger, f, indent=2)
+
+
+def register_plugin(code: str, parent_hash: str | None = None,
+                     lineage_map: dict | None = None, label: str | None = None) -> str:
+    ledger = load_ledger()
+    plugin_hash = _compute_hash(code)
+    if plugin_hash in ledger:
+        return plugin_hash
+
+    ledger[plugin_hash] = {
+        "plugin_hash": plugin_hash,
+        "parent_hash": parent_hash,
+        "lineage_map": lineage_map or {},
+        "label": label,
+        "timestamp": time.time(),
+    }
+    save_ledger(ledger)
+    return plugin_hash
+
+
+def get_lineage(plugin_hash: str) -> list[str]:
+    ledger = load_ledger()
+    lineage = []
+    current = plugin_hash
+    while current and current in ledger:
+        lineage.append(current)
+        current = ledger[current].get("parent_hash")
+    return lineage
+


### PR DESCRIPTION
## Summary
- introduce `net/plugin_ledger.py` to track plugin ancestry
- document ledger usage in `docs/manifest_ledger.md`
- link the new documentation from README

## Testing
- `python -m py_compile net/plugin_ledger.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f49bc5530832b914c97e0e1e287de