### PR TITLE
Implement plugin manifest signing and key rotation

### DIFF
--- a/crypto/identity/keys.py
+++ b/crypto/identity/keys.py
@@ -1,10 +1,15 @@
 # Node's own identity management
 import os
+import json
+import base64
+import hashlib
+from datetime import datetime
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives import serialization
 
 KEY_DIR = "crypto/keys"
 PRIVATE_KEY_PATH = os.path.join(KEY_DIR, "node_private_key.pem")
+ROTATIONS_PATH = os.path.join(KEY_DIR, "rotations.json")
 
 def generate_keypair():
     private_key = Ed25519PrivateKey.generate()
@@ -15,6 +20,15 @@ def generate_keypair():
             encryption_algorithm=serialization.NoEncryption()
         ))
     return private_key
+
+def _save_private_key(private_key):
+    os.makedirs(KEY_DIR, exist_ok=True)
+    with open(PRIVATE_KEY_PATH, "wb") as f:
+        f.write(private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
+        ))
 
 def load_keys():
     if not os.path.exists(PRIVATE_KEY_PATH):
@@ -29,3 +43,47 @@ def load_keys():
 
 def load_public_key():
     return load_keys().public_key()
+
+def rotate_keys():
+    old_key = load_keys()
+    new_key = Ed25519PrivateKey.generate()
+    _save_private_key(new_key)
+
+    rotation_record = {
+        "node_id": hashlib.sha256(
+            old_key.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw
+            )
+        ).hexdigest()[:16],
+        "current_key": base64.b64encode(
+            new_key.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw
+            )
+        ).decode("utf-8"),
+        "prev_keys": [],
+        "rotation_signature": base64.b64encode(
+            old_key.sign(
+                new_key.public_key().public_bytes(
+                    encoding=serialization.Encoding.Raw,
+                    format=serialization.PublicFormat.Raw
+                )
+            )
+        ).decode("utf-8"),
+        "rotated_at": datetime.utcnow().isoformat() + "Z",
+    }
+
+    try:
+        if os.path.exists(ROTATIONS_PATH):
+            with open(ROTATIONS_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        else:
+            data = []
+    except Exception:
+        data = []
+
+    data.append(rotation_record)
+    with open(ROTATIONS_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    return new_key

--- a/crypto/manifest_signer.py
+++ b/crypto/manifest_signer.py
@@ -1,0 +1,26 @@
+import json
+import base64
+import hashlib
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.exceptions import InvalidSignature
+
+
+def _hash_dict(data: dict) -> bytes:
+    serialized = json.dumps(data, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(serialized).digest()
+
+
+def sign_manifest(manifest: dict, private_key: Ed25519PrivateKey) -> str:
+    h = _hash_dict(manifest)
+    signature = private_key.sign(h)
+    return base64.b64encode(signature).decode("utf-8")
+
+
+def verify_manifest(manifest: dict, signature_b64: str, public_key: Ed25519PublicKey) -> bool:
+    h = _hash_dict(manifest)
+    try:
+        signature = base64.b64decode(signature_b64)
+        public_key.verify(signature, h)
+        return True
+    except (InvalidSignature, ValueError):
+        return False

--- a/memory/plugin_manifest.py
+++ b/memory/plugin_manifest.py
@@ -1,0 +1,28 @@
+import json
+import os
+from typing import Dict, Any
+
+MANIFEST_PATH = "memory/plugin_manifest.json"
+
+
+def _load() -> Dict[str, Any]:
+    if not os.path.exists(MANIFEST_PATH):
+        return {}
+    with open(MANIFEST_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _save(data: Dict[str, Any]):
+    os.makedirs(os.path.dirname(MANIFEST_PATH), exist_ok=True)
+    with open(MANIFEST_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def record_plugin(plugin_hash: str, metadata: Dict[str, Any]):
+    data = _load()
+    data[plugin_hash] = metadata
+    _save(data)
+
+
+def get_manifest() -> Dict[str, Any]:
+    return _load()


### PR DESCRIPTION
## Summary
- implement Ed25519 key rotation and save history
- add manifest signing and verification helpers
- track plugin metadata in a manifest file
- sign evolved plugins with node identity
- verify manifest signatures when loading plugins

## Testing
- `python -m py_compile crypto/manifest_signer.py memory/plugin_manifest.py plugins/plugin_genetic_evolver.py net/plugin_trigger_engine.py crypto/identity/keys.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f49ac7c70832b9bf2284fdff5bd20