### PR TITLE
Fix LLM auto vote endorsement call

### DIFF
--- a/plugins/plugin_llm_auto_vote.py
+++ b/plugins/plugin_llm_auto_vote.py
@@ -2,7 +2,8 @@ from memory.tagger import get_recent_memory, log_tagged_memory
 from inference.inference_worker import InferenceWorker
 import hashlib
 from memory.vector_logger import log_vector_record
-from trust.manager import endorse_peer
+from trust.endorsement_chain import endorse_peer
+from crypto.identity import get_node_id
 
 TRIGGER = {
     "type": "scheduled",
@@ -26,7 +27,8 @@ def handle_result(prompt, output, vector):
             raw = prompt.split("Proposing decision:")[1].split(":")[0]
             proposer = raw.strip()
             if vote == "yes":
-                endorse_peer(proposer, reason=f"Auto-voted yes for: {prompt}")
+                endorser = get_node_id()
+                endorse_peer(proposer, endorser, 1.0, f"Auto-voted yes for: {prompt}")
         except Exception as e:
             log_tagged_memory(f"[vote_plugin] Could not parse proposer: {e}", topic="decision", trust="low")
 


### PR DESCRIPTION
## Summary
- import `endorse_peer` from the proper module
- use current node ID when endorsing a peer

## Testing
- `python -m py_compile plugins/plugin_llm_auto_vote.py`
- `python -m py_compile trust/endorsement_chain.py`

------
https://chatgpt.com/codex/tasks/task_e_68412cc58a00832ba97dcfaf907b1952