### PR TITLE
Add plugin docstrings and regenerate docs

### DIFF
--- a/docs/plugins.json
+++ b/docs/plugins.json
@@ -1,14 +1,24 @@
 [
   {
     "name": "plugin_arp_watcher.py",
-    "description": "*No docstring provided.*",
+    "description": "Monitors ARP traffic to detect new devices and log them in a catalog.\n\nPassively captures network packets, which may reveal device information\nwithout consent.",
     "trigger": {
       "type": "passive"
     }
   },
   {
+    "name": "plugin_auto_vote.py",
+    "description": "Automatically votes on proposals found in recent memory entries.\n\nSimple heuristics may cast incorrect votes, influencing swarm decisions\nwithout human oversight.",
+    "trigger": {
+      "type": "event",
+      "match": {
+        "AAAAAAAAAAAAA": "AAAAAAAAAAAAA"
+      }
+    }
+  },
+  {
     "name": "plugin_dashboard_autopromote.py",
-    "description": "*No docstring provided.*",
+    "description": "Promotes this node to dashboard role if no dashboard is found.\n\nStarts web servers like Nginx and Uvicorn to host the dashboard.\nRunning network services may expose the node or consume resources.",
     "trigger": {
       "type": "event",
       "match": {
@@ -20,7 +30,7 @@
   },
   {
     "name": "plugin_dashboard_stepdown.py",
-    "description": "*No docstring provided.*",
+    "description": "Steps down from dashboard role when another dashboard is detected.\n\nStops Nginx and Uvicorn when relinquishing role. If misfired, it could\nshut down the local dashboard unexpectedly.",
     "trigger": {
       "type": "event",
       "match": {
@@ -31,20 +41,103 @@
   },
   {
     "name": "plugin_dashboard_sync.py",
-    "description": "*No docstring provided.*",
+    "description": "Synchronizes memory with the elected dashboard over gRPC.\n\nPeriodically sends local memory state to the dashboard. Can leak\nsensitive data over the network and increases bandwidth usage.",
     "trigger": {
       "type": "scheduled",
       "interval": 30
     }
   },
   {
+    "name": "plugin_genealogist.py",
+    "description": "Reports lineage information for evolved plugins by reading genome headers.\n\nUseful for tracing plugin origins but may reveal details about mutations\nor source nodes if leaked.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 900
+    }
+  },
+  {
     "name": "plugin_genetic_evolver.py",
-    "description": "plugin_genetic_evolver.py",
-    "trigger": null
+    "description": "Evolves existing plugins by randomly or LLM-assisted mutations.\n\nCreates new `plugin_evolved_*.py` files from crossover and mutation of\nother plugins. May execute arbitrary generated code, so use with care.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 900
+    }
+  },
+  {
+    "name": "plugin_inference_latency.py",
+    "description": "Logs average inference latency from recent inference worker statistics.\n\nHelps detect slowdown but continuously reading stats may affect\nperformance slightly.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 120
+    }
+  },
+  {
+    "name": "plugin_inference_monitor.py",
+    "description": "Monitors the inference queue size and logs warnings when backlog grows.\n\nMay generate many log entries under heavy load, filling memory quickly.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 60
+    }
+  },
+  {
+    "name": "plugin_instincts.py",
+    "description": "Executes instinctive behaviors based on recent memory patterns.\n\nCan trigger scanning or replication plugins automatically, which may be\nintrusive or resource intensive.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 300
+    }
   },
   {
     "name": "plugin_lan_scanner.py",
-    "description": "*No docstring provided.*",
+    "description": "Scans the local network for peers and open ports, updating host catalog.\n\nUseful for discovery but aggressive scanning could alert network monitors\nor violate policies.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 300
+    }
+  },
+  {
+    "name": "plugin_llm_auto_vote.py",
+    "description": "Uses an LLM to automatically vote on recent swarm decisions.\n\nLLM responses may be unpredictable and could endorse malicious actions\nif prompts are manipulated.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 120
+    }
+  },
+  {
+    "name": "plugin_llm_scheduler.py",
+    "description": "Asks an LLM to recommend scheduling or disabling plugins.\n\nRelies on AI judgments which may be poor or biased, potentially causing\nharmful plugin behavior changes.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 300
+    }
+  },
+  {
+    "name": "plugin_memory_interpreter.py",
+    "description": "Uses an LLM to summarize recent memory and provide swarm insights.\n\nCould leak private data via prompts and may misinterpret context,\nleading to misleading analysis.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 30
+    }
+  },
+  {
+    "name": "plugin_peer_quarantine.py",
+    "description": "Removes peers from the catalog that repeatedly fail handshakes.\n\nHelps prune unreachable nodes but might accidentally quarantine healthy\npeers if network issues are temporary.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 600
+    }
+  },
+  {
+    "name": "plugin_pruner.py",
+    "description": "Deletes evolved plugins that show poor performance or inactivity.\n\nHelps control plugin sprawl but could remove useful plugins if criteria\nare too aggressive.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 600
+    }
+  },
+  {
+    "name": "plugin_replicator.py",
+    "description": "Replicates the newest evolved plugin to a random online peer.\n\nFacilitates code propagation across the swarm. Can spread malicious or\nunstable plugins if not carefully monitored.",
     "trigger": {
       "type": "scheduled",
       "interval": 300
@@ -52,7 +145,7 @@
   },
   {
     "name": "plugin_smb_replicator.py",
-    "description": "*No docstring provided.*",
+    "description": "Copies the node executable to writable SMB or removable drives.\n\nEnables spreading to Windows shares and may hide the payload. This is\novert malware-like behavior and is high risk.",
     "trigger": {
       "type": "event",
       "match": {
@@ -63,13 +156,36 @@
   },
   {
     "name": "plugin_update_proxy.py",
-    "description": "*No docstring provided.*",
+    "description": "Updates the nginx proxy configuration when a new dashboard is elected.\n\nReads memory logs to find the latest dashboard IP and rewrites config.\nImproper configuration could break access or expose the node.",
     "trigger": {
       "type": "event",
       "match": {
         "topic": "role",
         "role": "dashboard"
       }
+    }
+  },
+  {
+    "name": "plugin_vote_aggregator.py",
+    "description": "Aggregates swarm votes from memory and logs a summary.\n\nPurely informational but could be misleading if memory contains spam or\nmanipulated votes.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 300
+    }
+  },
+  {
+    "name": "plugin_vote_promoter.py",
+    "description": "Publishes vote summaries and promotes approved actions.\n\nCan inadvertently promote malicious proposals if vote data is tampered.",
+    "trigger": {
+      "type": "scheduled",
+      "interval": 300
+    }
+  },
+  {
+    "name": "plugin_ws_sadl_sniffer.py",
+    "description": "Intercepts WebSocket traffic using NFQUEUE or scapy and logs packets.\n\nCan capture sensitive data and requires elevated privileges on Linux.",
+    "trigger": {
+      "type": "manual"
     }
   }
 ]

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,7 +2,10 @@
 
 ## `plugin_arp_watcher.py`
 
-*No docstring provided.*
+Monitors ARP traffic to detect new devices and log them in a catalog.
+
+Passively captures network packets, which may reveal device information
+without consent.
 
 **Trigger:**
 ```json
@@ -13,9 +16,31 @@
 
 ---
 
+## `plugin_auto_vote.py`
+
+Automatically votes on proposals found in recent memory entries.
+
+Simple heuristics may cast incorrect votes, influencing swarm decisions
+without human oversight.
+
+**Trigger:**
+```json
+{
+  "type": "event",
+  "match": {
+    "AAAAAAAAAAAAA": "AAAAAAAAAAAAA"
+  }
+}
+```
+
+---
+
 ## `plugin_dashboard_autopromote.py`
 
-*No docstring provided.*
+Promotes this node to dashboard role if no dashboard is found.
+
+Starts web servers like Nginx and Uvicorn to host the dashboard.
+Running network services may expose the node or consume resources.
 
 **Trigger:**
 ```json
@@ -33,7 +58,10 @@
 
 ## `plugin_dashboard_stepdown.py`
 
-*No docstring provided.*
+Steps down from dashboard role when another dashboard is detected.
+
+Stops Nginx and Uvicorn when relinquishing role. If misfired, it could
+shut down the local dashboard unexpectedly.
 
 **Trigger:**
 ```json
@@ -50,7 +78,10 @@
 
 ## `plugin_dashboard_sync.py`
 
-*No docstring provided.*
+Synchronizes memory with the elected dashboard over gRPC.
+
+Periodically sends local memory state to the dashboard. Can leak
+sensitive data over the network and increases bandwidth usage.
 
 **Trigger:**
 ```json
@@ -62,15 +93,198 @@
 
 ---
 
+## `plugin_genealogist.py`
+
+Reports lineage information for evolved plugins by reading genome headers.
+
+Useful for tracing plugin origins but may reveal details about mutations
+or source nodes if leaked.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 900
+}
+```
+
+---
+
 ## `plugin_genetic_evolver.py`
 
-plugin_genetic_evolver.py
+Evolves existing plugins by randomly or LLM-assisted mutations.
+
+Creates new `plugin_evolved_*.py` files from crossover and mutation of
+other plugins. May execute arbitrary generated code, so use with care.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 900
+}
+```
+
+---
+
+## `plugin_inference_latency.py`
+
+Logs average inference latency from recent inference worker statistics.
+
+Helps detect slowdown but continuously reading stats may affect
+performance slightly.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 120
+}
+```
+
+---
+
+## `plugin_inference_monitor.py`
+
+Monitors the inference queue size and logs warnings when backlog grows.
+
+May generate many log entries under heavy load, filling memory quickly.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 60
+}
+```
+
+---
+
+## `plugin_instincts.py`
+
+Executes instinctive behaviors based on recent memory patterns.
+
+Can trigger scanning or replication plugins automatically, which may be
+intrusive or resource intensive.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 300
+}
+```
 
 ---
 
 ## `plugin_lan_scanner.py`
 
-*No docstring provided.*
+Scans the local network for peers and open ports, updating host catalog.
+
+Useful for discovery but aggressive scanning could alert network monitors
+or violate policies.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 300
+}
+```
+
+---
+
+## `plugin_llm_auto_vote.py`
+
+Uses an LLM to automatically vote on recent swarm decisions.
+
+LLM responses may be unpredictable and could endorse malicious actions
+if prompts are manipulated.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 120
+}
+```
+
+---
+
+## `plugin_llm_scheduler.py`
+
+Asks an LLM to recommend scheduling or disabling plugins.
+
+Relies on AI judgments which may be poor or biased, potentially causing
+harmful plugin behavior changes.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 300
+}
+```
+
+---
+
+## `plugin_memory_interpreter.py`
+
+Uses an LLM to summarize recent memory and provide swarm insights.
+
+Could leak private data via prompts and may misinterpret context,
+leading to misleading analysis.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 30
+}
+```
+
+---
+
+## `plugin_peer_quarantine.py`
+
+Removes peers from the catalog that repeatedly fail handshakes.
+
+Helps prune unreachable nodes but might accidentally quarantine healthy
+peers if network issues are temporary.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 600
+}
+```
+
+---
+
+## `plugin_pruner.py`
+
+Deletes evolved plugins that show poor performance or inactivity.
+
+Helps control plugin sprawl but could remove useful plugins if criteria
+are too aggressive.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 600
+}
+```
+
+---
+
+## `plugin_replicator.py`
+
+Replicates the newest evolved plugin to a random online peer.
+
+Facilitates code propagation across the swarm. Can spread malicious or
+unstable plugins if not carefully monitored.
 
 **Trigger:**
 ```json
@@ -84,7 +298,10 @@ plugin_genetic_evolver.py
 
 ## `plugin_smb_replicator.py`
 
-*No docstring provided.*
+Copies the node executable to writable SMB or removable drives.
+
+Enables spreading to Windows shares and may hide the payload. This is
+overt malware-like behavior and is high risk.
 
 **Trigger:**
 ```json
@@ -101,7 +318,10 @@ plugin_genetic_evolver.py
 
 ## `plugin_update_proxy.py`
 
-*No docstring provided.*
+Updates the nginx proxy configuration when a new dashboard is elected.
+
+Reads memory logs to find the latest dashboard IP and rewrites config.
+Improper configuration could break access or expose the node.
 
 **Trigger:**
 ```json
@@ -111,6 +331,54 @@ plugin_genetic_evolver.py
     "topic": "role",
     "role": "dashboard"
   }
+}
+```
+
+---
+
+## `plugin_vote_aggregator.py`
+
+Aggregates swarm votes from memory and logs a summary.
+
+Purely informational but could be misleading if memory contains spam or
+manipulated votes.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 300
+}
+```
+
+---
+
+## `plugin_vote_promoter.py`
+
+Publishes vote summaries and promotes approved actions.
+
+Can inadvertently promote malicious proposals if vote data is tampered.
+
+**Trigger:**
+```json
+{
+  "type": "scheduled",
+  "interval": 300
+}
+```
+
+---
+
+## `plugin_ws_sadl_sniffer.py`
+
+Intercepts WebSocket traffic using NFQUEUE or scapy and logs packets.
+
+Can capture sensitive data and requires elevated privileges on Linux.
+
+**Trigger:**
+```json
+{
+  "type": "manual"
 }
 ```
 

--- a/plugins/plugin_arp_watcher.py
+++ b/plugins/plugin_arp_watcher.py
@@ -1,3 +1,9 @@
+"""Monitors ARP traffic to detect new devices and log them in a catalog.
+
+Passively captures network packets, which may reveal device information
+without consent.
+"""
+
 from scapy.all import sniff, ARP
 from memory.tagger import log_tagged_memory
 import threading

--- a/plugins/plugin_auto_vote.py
+++ b/plugins/plugin_auto_vote.py
@@ -1,3 +1,9 @@
+"""Automatically votes on proposals found in recent memory entries.
+
+Simple heuristics may cast incorrect votes, influencing swarm decisions
+without human oversight.
+"""
+
 from memory.tagger import get_recent_memory, log_tagged_memory
 
 TRIGGER = {

--- a/plugins/plugin_dashboard_autopromote.py
+++ b/plugins/plugin_dashboard_autopromote.py
@@ -1,3 +1,9 @@
+"""Promotes this node to dashboard role if no dashboard is found.
+
+Starts web servers like Nginx and Uvicorn to host the dashboard.
+Running network services may expose the node or consume resources.
+"""
+
 import time
 import socket
 import subprocess

--- a/plugins/plugin_dashboard_stepdown.py
+++ b/plugins/plugin_dashboard_stepdown.py
@@ -1,3 +1,9 @@
+"""Steps down from dashboard role when another dashboard is detected.
+
+Stops Nginx and Uvicorn when relinquishing role. If misfired, it could
+shut down the local dashboard unexpectedly.
+"""
+
 import time
 import socket
 import subprocess

--- a/plugins/plugin_dashboard_sync.py
+++ b/plugins/plugin_dashboard_sync.py
@@ -1,3 +1,9 @@
+"""Synchronizes memory with the elected dashboard over gRPC.
+
+Periodically sends local memory state to the dashboard. Can leak
+sensitive data over the network and increases bandwidth usage.
+"""
+
 import socket
 import time
 import hashlib

--- a/plugins/plugin_genealogist.py
+++ b/plugins/plugin_genealogist.py
@@ -1,3 +1,8 @@
+"""Reports lineage information for evolved plugins by reading genome headers.
+
+Useful for tracing plugin origins but may reveal details about mutations
+or source nodes if leaked.
+"""
 
 import os
 import json

--- a/plugins/plugin_genetic_evolver.py
+++ b/plugins/plugin_genetic_evolver.py
@@ -1,3 +1,8 @@
+"""Evolves existing plugins by randomly or LLM-assisted mutations.
+
+Creates new `plugin_evolved_*.py` files from crossover and mutation of
+other plugins. May execute arbitrary generated code, so use with care.
+"""
 
 import os
 import random

--- a/plugins/plugin_inference_latency.py
+++ b/plugins/plugin_inference_latency.py
@@ -1,3 +1,9 @@
+"""Logs average inference latency from recent inference worker statistics.
+
+Helps detect slowdown but continuously reading stats may affect
+performance slightly.
+"""
+
 import time
 import json
 from statistics import mean

--- a/plugins/plugin_inference_monitor.py
+++ b/plugins/plugin_inference_monitor.py
@@ -1,3 +1,8 @@
+"""Monitors the inference queue size and logs warnings when backlog grows.
+
+May generate many log entries under heavy load, filling memory quickly.
+"""
+
 import time
 from memory.tagger import log_tagged_memory
 from inference.inference_worker import InferenceWorker

--- a/plugins/plugin_instincts.py
+++ b/plugins/plugin_instincts.py
@@ -1,3 +1,8 @@
+"""Executes instinctive behaviors based on recent memory patterns.
+
+Can trigger scanning or replication plugins automatically, which may be
+intrusive or resource intensive.
+"""
 
 from memory.tagger import get_recent_memory, log_tagged_memory
 from net.plugin_trigger_engine import run_plugins_by_trigger

--- a/plugins/plugin_lan_scanner.py
+++ b/plugins/plugin_lan_scanner.py
@@ -1,3 +1,9 @@
+"""Scans the local network for peers and open ports, updating host catalog.
+
+Useful for discovery but aggressive scanning could alert network monitors
+or violate policies.
+"""
+
 import socket
 import ipaddress
 import json

--- a/plugins/plugin_llm_auto_vote.py
+++ b/plugins/plugin_llm_auto_vote.py
@@ -1,3 +1,9 @@
+"""Uses an LLM to automatically vote on recent swarm decisions.
+
+LLM responses may be unpredictable and could endorse malicious actions
+if prompts are manipulated.
+"""
+
 from memory.tagger import get_recent_memory, log_tagged_memory
 from inference.inference_worker import InferenceWorker
 import hashlib

--- a/plugins/plugin_llm_scheduler.py
+++ b/plugins/plugin_llm_scheduler.py
@@ -1,3 +1,9 @@
+"""Asks an LLM to recommend scheduling or disabling plugins.
+
+Relies on AI judgments which may be poor or biased, potentially causing
+harmful plugin behavior changes.
+"""
+
 from memory.tagger import get_recent_memory, log_tagged_memory
 from inference.inference_worker import InferenceWorker
 import hashlib

--- a/plugins/plugin_memory_interpreter.py
+++ b/plugins/plugin_memory_interpreter.py
@@ -1,3 +1,9 @@
+"""Uses an LLM to summarize recent memory and provide swarm insights.
+
+Could leak private data via prompts and may misinterpret context,
+leading to misleading analysis.
+"""
+
 import os
 import sys
 import signal

--- a/plugins/plugin_peer_quarantine.py
+++ b/plugins/plugin_peer_quarantine.py
@@ -1,3 +1,8 @@
+"""Removes peers from the catalog that repeatedly fail handshakes.
+
+Helps prune unreachable nodes but might accidentally quarantine healthy
+peers if network issues are temporary.
+"""
 
 import json
 from memory.tagger import get_recent_memory, log_tagged_memory

--- a/plugins/plugin_pruner.py
+++ b/plugins/plugin_pruner.py
@@ -1,3 +1,8 @@
+"""Deletes evolved plugins that show poor performance or inactivity.
+
+Helps control plugin sprawl but could remove useful plugins if criteria
+are too aggressive.
+"""
 
 import os
 import time

--- a/plugins/plugin_replicator.py
+++ b/plugins/plugin_replicator.py
@@ -1,3 +1,8 @@
+"""Replicates the newest evolved plugin to a random online peer.
+
+Facilitates code propagation across the swarm. Can spread malicious or
+unstable plugins if not carefully monitored.
+"""
 
 import os
 import random

--- a/plugins/plugin_smb_replicator.py
+++ b/plugins/plugin_smb_replicator.py
@@ -1,3 +1,9 @@
+"""Copies the node executable to writable SMB or removable drives.
+
+Enables spreading to Windows shares and may hide the payload. This is
+overt malware-like behavior and is high risk.
+"""
+
 import os
 import shutil
 import time

--- a/plugins/plugin_update_proxy.py
+++ b/plugins/plugin_update_proxy.py
@@ -1,3 +1,9 @@
+"""Updates the nginx proxy configuration when a new dashboard is elected.
+
+Reads memory logs to find the latest dashboard IP and rewrites config.
+Improper configuration could break access or expose the node.
+"""
+
 import json
 import os
 import time

--- a/plugins/plugin_vote_aggregator.py
+++ b/plugins/plugin_vote_aggregator.py
@@ -1,3 +1,9 @@
+"""Aggregates swarm votes from memory and logs a summary.
+
+Purely informational but could be misleading if memory contains spam or
+manipulated votes.
+"""
+
 from memory.tagger import get_recent_memory, log_tagged_memory
 from net.swarm_vote import swarm_vote
 

--- a/plugins/plugin_vote_promoter.py
+++ b/plugins/plugin_vote_promoter.py
@@ -1,3 +1,8 @@
+"""Publishes vote summaries and promotes approved actions.
+
+Can inadvertently promote malicious proposals if vote data is tampered.
+"""
+
 from memory.tagger import get_recent_memory, log_tagged_memory
 from net.swarm_vote import swarm_vote
 

--- a/plugins/plugin_ws_sadl_sniffer.py
+++ b/plugins/plugin_ws_sadl_sniffer.py
@@ -1,3 +1,7 @@
+"""Intercepts WebSocket traffic using NFQUEUE or scapy and logs packets.
+
+Can capture sensitive data and requires elevated privileges on Linux.
+"""
 # GENOME:
 # origin=plugin_ws_sadl_sniffer
 # generation=1


### PR DESCRIPTION
## Summary
- document all plugins with short docstrings including risks
- regenerate plugin documentation

## Testing
- `python3 scripts/genDocs.py`

------
https://chatgpt.com/codex/tasks/task_e_68413b131c7c832bb6e073d26a67e818