### PR TITLE
Update swarm_vote to return counts

### DIFF
--- a/net/swarm_vote.py
+++ b/net/swarm_vote.py
@@ -1,6 +1,6 @@
-import yaml
 import json
 from collections import Counter
+from typing import Iterable, Union, Dict, Any
 from memory.tagger import log_tagged_memory
 
 def load_peer_logs(paths):
@@ -13,15 +13,53 @@ def load_peer_logs(paths):
             continue
     return merged
 
-def swarm_vote(logs, tag="decision"):
-    votes = []
-    for line in logs:
-        if f"[topic:{tag}]" in line:
-            content = line.split("]")[-1].strip()
-            votes.append(content)
-    if not votes:
+def _parse_entry(entry: Union[str, Dict[str, Any]], tag: str) -> str:
+    """Extract the vote text from a memory entry if it matches the tag."""
+    if isinstance(entry, dict):
+        if entry.get("topic") != tag:
+            return ""
+        content = entry.get("content", "")
+        if isinstance(content, dict):
+            content = str(content)
+        return str(content)
+
+    if isinstance(entry, str):
+        try:
+            data = json.loads(entry)
+            return _parse_entry(data, tag)
+        except Exception:
+            if f"[topic:{tag}]" not in entry:
+                return ""
+            return entry.split("]")[-1].strip()
+    return ""
+
+
+def swarm_vote(logs: Iterable[Union[str, Dict[str, Any]]], tag: str = "decision") -> Dict[str, int]:
+    """Tally yes/no/abstain votes from memory logs."""
+    counts = Counter()
+    for entry in logs:
+        text = _parse_entry(entry, tag).lower()
+        if "vote yes" in text:
+            counts["yes"] += 1
+        elif "vote no" in text:
+            counts["no"] += 1
+        elif "vote abstain" in text:
+            counts["abstain"] += 1
+
+    if not counts:
         return None
-    count = Counter(votes)
-    winner = count.most_common(1)[0]
-    log_tagged_memory(f"Swarm consensus on '{tag}': {winner[0]} ({winner[1]} votes)", topic="swarm", trust="high")
-    return winner[0]
+
+    result = {
+        "yes": counts.get("yes", 0),
+        "no": counts.get("no", 0),
+        "abstain": counts.get("abstain", 0),
+    }
+    result["net"] = result["yes"] - result["no"]
+
+    log_tagged_memory(
+        f"Swarm consensus on '{tag}': YES={result['yes']} NO={result['no']} ABSTAIN={result['abstain']} Net={result['net']}",
+        topic="swarm",
+        trust="high",
+    )
+
+    return result

--- a/plugins/plugin_vote_aggregator.py
+++ b/plugins/plugin_vote_aggregator.py
@@ -9,6 +9,8 @@ TRIGGER = {
 def run():
     logs = get_recent_memory(limit=200)
     result = swarm_vote(logs, tag="decision")
+    if not result:
+        return
 
     summary = (
         f"Vote results: YES={result['yes']} | NO={result['no']} | ABSTAIN={result['abstain']}"

--- a/plugins/plugin_vote_promoter.py
+++ b/plugins/plugin_vote_promoter.py
@@ -9,6 +9,8 @@ TRIGGER = {
 def run():
     logs = get_recent_memory(limit=200)
     result = swarm_vote(logs, tag="decision")
+    if not result:
+        return
 
     summary = (
         f"[Vote Summary] YES={result['yes']} | NO={result['no']} | ABSTAIN={result['abstain']} | Net={result['net']}"


### PR DESCRIPTION
## Summary
- extend `swarm_vote` to parse JSON logs and tally yes/no/abstain counts
- guard vote plugins against no vote results

## Testing
- `python3 -m py_compile net/swarm_vote.py plugins/plugin_vote_aggregator.py plugins/plugin_vote_promoter.py`
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6841357489d4832b8975069a21a1deb4